### PR TITLE
autoplaySpeed prop type Number and Boolean

### DIFF
--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -126,7 +126,7 @@ export default {
       default: false,
     },
     autoplaySpeed: {
-      type: Boolean,
+      type: [Number, Boolean],
       default: false,
     },
     autoplayTimeout: {


### PR DESCRIPTION
https://github.com/s950329/vue-owl-carousel#autoplayspeed

The "autoplaySpeed" props need to support Number or Boolean types, but supported only Boolean type.

